### PR TITLE
Upgrade Open OnDemand to v3

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -93,8 +93,7 @@ RUN mkdir /etc/sysconfig/slurm \
         /var/lib/slurmd/fed_mgr_state \
     && useradd -r --uid=990 slurm \
     && chown -R slurm:slurm /var/*/slurm* \
-    && useradd -u 1000 rocky \
-    && usermod -p 'openssl password' rocky
+    && useradd -u 1000 rocky
 
 VOLUME /etc/slurm
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex \
        openssh-server \
        apptainer \
        ondemand \
+       passwd \
        mod_authnz_pam \
     && yum clean all \
     && rm -rf /var/cache/yum

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     && yum -y install dnf-plugins-core epel-release \
     && yum -y install dnf-plugins-core \
     && yum config-manager --set-enabled powertools \
-    && yum -y module enable ruby:2.7 nodejs:14 \
+    && yum module enable ruby:3.0 nodejs:14 \
     && yum -y install https://yum.osc.edu/ondemand/3.0/ondemand-release-web-3.0-1.noarch.rpm \
     && yum -y module install ruby nodejs \
     && yum -y install \

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -46,6 +46,7 @@ RUN set -ex \
        openssh-server \
        apptainer \
        ondemand \
+       mod_authnz_pam
     && yum clean all \
     && rm -rf /var/cache/yum
 
@@ -93,7 +94,7 @@ RUN mkdir /etc/sysconfig/slurm \
     && useradd -r --uid=990 slurm \
     && chown -R slurm:slurm /var/*/slurm* \
     && useradd -u 1000 rocky \
-    && usermod -p '*' rocky # unlocks account but sets no password
+    && usermod -p 'openssl password' rocky
 
 VOLUME /etc/slurm
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     && yum -y install dnf-plugins-core epel-release \
     && yum -y install dnf-plugins-core \
     && yum config-manager --set-enabled powertools \
-    && yum module enable ruby:3.0 nodejs:14 \
+    && yum -y module enable ruby:3.0 nodejs:14 \
     && yum -y install https://yum.osc.edu/ondemand/3.0/ondemand-release-web-3.0-1.noarch.rpm \
     && yum -y module install ruby nodejs \
     && yum -y install \

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -46,7 +46,7 @@ RUN set -ex \
        openssh-server \
        apptainer \
        ondemand \
-       mod_authnz_pam
+       mod_authnz_pam \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
     && yum -y install dnf-plugins-core \
     && yum config-manager --set-enabled powertools \
     && yum -y module enable ruby:2.7 nodejs:14 \
-    && yum -y install https://yum.osc.edu/ondemand/2.0/ondemand-release-web-2.0-1.noarch.rpm \
+    && yum -y install https://yum.osc.edu/ondemand/3.0/ondemand-release-web-3.0-1.noarch.rpm \
     && yum -y module install ruby nodejs \
     && yum -y install \
        wget \

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -86,7 +86,7 @@ then
     chown root:root /home
     chmod 755 /home
 
-    echo $OOD_PASS | passwd --stdin rocky
+    echo "$OOD_PASS" | passwd --stdin rocky
 
     echo "---> Setting up ssh for user"
 

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -134,7 +134,7 @@ then
     /usr/libexec/httpd-ssl-gencerts
 
     echo "LoadModule authnz_pam_module modules/mod_authnz_pam.so" > /etc/httpd/conf.modules.d/55-authnz_pam.conf
-    cp /etc/pam.d/sshd /etc/pam.d/ood
+    cp /etc/pam.d/password-auth /etc/pam.d/ood
     chmod 640 /etc/shadow
     chgrp apache /etc/shadow
 

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -130,10 +130,12 @@ then
     env > /etc/ood/config/apps/shell/env
 
     /usr/libexec/httpd-ssl-gencerts
-    /opt/ood/ood-portal-generator/sbin/update_ood_portal
-    mkdir --parents /opt/rh/httpd24/root/etc/httpd/
 
+    mkdir --parents /opt/rh/httpd24/root/etc/httpd/
     /usr/bin/htpasswd -cb /opt/rh/httpd24/root/etc/httpd/apache-passwords rocky $ROCKY_OOD_PASS
+
+    /opt/ood/ood-portal-generator/sbin/update_ood_portal
+    
     /usr/sbin/httpd -k start -X -e debug
 
 elif [ "$1" = "check-queue-hook" ]

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -86,6 +86,8 @@ then
     chown root:root /home
     chmod 755 /home
 
+    echo $OOD_PASS | passwd --stdin rocky
+
     echo "---> Setting up ssh for user"
 
     mkdir -p /home/rocky/.ssh

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -131,6 +131,10 @@ then
 
     /usr/libexec/httpd-ssl-gencerts
 
+    cp /etc/pam.d/sshd /etc/pam.d/ood
+    chmod 640 /etc/shadow
+    chgrp apache /etc/shadow
+
     mkdir --parents /opt/rh/httpd24/root/etc/httpd/
     /usr/bin/htpasswd -cb /opt/rh/httpd24/root/etc/httpd/apache-passwords rocky $ROCKY_OOD_PASS
 

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -131,6 +131,7 @@ then
 
     /usr/libexec/httpd-ssl-gencerts
 
+    echo "LoadModule authnz_pam_module modules/mod_authnz_pam.so" > /etc/httpd/conf.modules.d/55-authnz_pam.conf
     cp /etc/pam.d/sshd /etc/pam.d/ood
     chmod 640 /etc/shadow
     chgrp apache /etc/shadow

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -86,7 +86,7 @@ then
     chown root:root /home
     chmod 755 /home
 
-    echo "$OOD_PASS" | passwd --stdin rocky
+    echo $ROCKY_OOD_PASS | passwd --stdin rocky
 
     echo "---> Setting up ssh for user"
 

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -95,6 +95,7 @@ then
         echo "ssh keys already found"
     else
             ssh-keygen -t rsa -f /home/rocky/.ssh/id_rsa -N ""
+            chown rocky:rocky /home/rocky/.ssh/id_rsa /home/rocky/.ssh/id_rsa.pub
     fi
 
     echo "---> Setting permissions for user home directories"
@@ -132,7 +133,7 @@ then
     /opt/ood/ood-portal-generator/sbin/update_ood_portal
     mkdir --parents /opt/rh/httpd24/root/etc/httpd/
 
-    /usr/bin/htdbm -cb /opt/rh/httpd24/root/etc/httpd/.htpasswd.dbm rocky $ROCKY_OOD_PASS
+    /usr/bin/htpasswd -cb /opt/rh/httpd24/root/etc/httpd/apache-passwords rocky $ROCKY_OOD_PASS
     /usr/sbin/httpd -k start -X -e debug
 
 elif [ "$1" = "check-queue-hook" ]

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -141,6 +141,8 @@ then
     mkdir --parents /opt/rh/httpd24/root/etc/httpd/
     /usr/bin/htpasswd -cb /opt/rh/httpd24/root/etc/httpd/apache-passwords rocky $ROCKY_OOD_PASS
 
+    echo "config.hosts = nil" >> /var/www/ood/apps/sys/dashboard/config/environments/production.rb
+
     /opt/ood/ood-portal-generator/sbin/update_ood_portal
     
     /usr/sbin/httpd -k start -X -e debug

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -141,7 +141,10 @@ then
     mkdir --parents /opt/rh/httpd24/root/etc/httpd/
     /usr/bin/htpasswd -cb /opt/rh/httpd24/root/etc/httpd/apache-passwords rocky $ROCKY_OOD_PASS
 
-    echo "config.hosts = nil" >> /var/www/ood/apps/sys/dashboard/config/environments/production.rb
+    head -102 /var/www/ood/apps/sys/dashboard/config/environments/production.rb > tmp.txt
+    cat tmp.txt > /var/www/ood/apps/sys/dashboard/config/environments/production.rb
+    echo "  config.hosts = nil" >> /var/www/ood/apps/sys/dashboard/config/environments/production.rb
+    echo "end" >> /var/www/ood/apps/sys/dashboard/config/environments/production.rb
 
     /opt/ood/ood-portal-generator/sbin/update_ood_portal
     

--- a/slurm-cluster-chart/files/ood_portal.yaml
+++ b/slurm-cluster-chart/files/ood_portal.yaml
@@ -8,19 +8,30 @@
 # Example:
 #     listen_addr_port: 443
 # Default: null (don't add any more listen directives)
-#listen_addr_port: 80
+#listen_addr_port: null
 
 # The server name used for name-based Virtual Host
 # Example:
 #     servername: 'www.example.com'
 # Default: null (don't use name-based Virtual Host)
-#servername: 128.232.226.84
-#serverAlias: 128.232.226.84
+#servername: null
+
+# The server aliases used for the name-based Virtual Host
+# Example:
+#     server_aliases:
+#       - foo.example.com
+#server_aliases: []
+
+# The server name used for rewrites
+# Example:
+#     proxy_server: 'proxy.example.com'
+# Default: The value of servername
+#proxy_server: null
 
 # The port specification for the Virtual Host
 # Example:
 #     port: 8080
-#Default: null (use default port 80 or 443 if SSL enabled)
+# Default: null (use default port 80 or 443 if SSL enabled)
 #port: null
 
 # List of SSL Apache directives
@@ -29,7 +40,6 @@
 #       - 'SSLCertificateFile "/etc/pki/tls/certs/www.example.com.crt"'
 #       - 'SSLCertificateKeyFile "/etc/pki/tls/private/www.example.com.key"'
 # Default: null (no SSL support)
-#ssl: null
 ssl:
 - 'SSLCertificateFile "/etc/pki/tls/certs/localhost.crt"'
 - 'SSLCertificateKeyFile "/etc/pki/tls/private/localhost.key"'
@@ -39,6 +49,60 @@ ssl:
 #     logroot: '/path/to/my/logs'
 # Default: 'logs' (this is relative to ServerRoot)
 #logroot: 'logs'
+
+# Error log filename
+# Example:
+#     errorlog: 'error.log'
+# Default: 'error.log' (If 'servername' and 'ssl' options are defined
+# the default value will be <servername>_error_ssl.log)
+#errorlog: 'error.log'
+
+# Access log filename
+# Example:
+#     accesslog: 'access.log'
+# Default: 'access.log' (If 'servername' and 'ssl' options are defined
+# the default value will be <servername>_access_ssl.log)
+#accesslog: 'access.log'
+
+# Apache access log format (Don't specify log nickname see: http://httpd.apache.org/docs/current/mod/mod_log_config.html#transferlog)
+# Example:
+#     logformat: '"%v %h \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\" %{SSL_PROTOCOL}x %T"'
+# Default: Apache combined format
+#logformat: Apache combine format
+
+# Should RewriteEngine be used
+# Example:
+#     use_rewrites: false
+# Default: true
+#use_rewrites: true
+
+# Should Maintenance Rewrite rules be added
+# Example:
+#   use_maintenance: false
+# Default: true
+#use_maintenance: true
+
+# List of IPs to allowed when maintenance is enabled
+# Example:
+#   maintenance_ip_allowlist:
+#     - 192.168.0..*
+#     - 192.168.1..*
+# Default: [] (no IPs allowed)
+#maintenance_ip_allowlist: []
+
+# Set Header Content-Security-Policy frame-ancestors.
+# Example:
+#   security_csp_frame_ancestors: https://ondemand.osc.edu
+# Example to disable setting:
+#   security_csp_frame_ancestors: false
+# Default: based on servername and ssl settings
+#security_csp_frame_ancestors:
+
+# Set Header Strict-Transport-Security to help enforce SSL
+# Example:
+#   security_strict_transport: false
+# Default: true when ssl is enabled, false otherwise
+#security_strict_transport: false
 
 # Root directory of the Lua handler code
 # Example:
@@ -53,11 +117,19 @@ ssl:
 # Default: 'info' (get verbose logs)
 #lua_log_level: 'info'
 
-# System command used to map authenticated-user to system-user
+# Lua regular expression used to map authenticated-user to system-user
+# This configuration is ignored if user_map_cmd is defined
 # Example:
-#     user_map_cmd: '/opt/ood/ood_auth_map/bin/ood_auth_map.regex --regex=''^(\w+)@example.com$'''
-# Default: '/opt/ood/ood_auth_map/bin/ood_auth_map.regex' (this echo's back auth-user)
-#user_map_cmd: '/opt/ood/ood_auth_map/bin/ood_auth_map.regex'
+#     user_map_match: '^([^@]+)@.*$'
+# Default: '.*'
+#user_map_match: '.*'
+
+# System command used to map authenticated-user to system-user
+# This option takes precedence over user_map_match
+# Example:
+#     user_map_cmd: '/usr/local/bin/ondemand-usermap'
+# Default: null (use user_map_match)
+#user_map_cmd: null
 
 # Use an alternative CGI environment variable instead of REMOTE_USER for
 # determining the authenticated-user fed to the mapping script
@@ -81,13 +153,17 @@ ssl:
 
 # List of Apache authentication directives
 # NB: Be sure the appropriate Apache module is installed for this
-# Default: (see below, uses basic auth with an htpasswd file)
-# auth:
-#   - 'AuthType Basic'
-#   - 'AuthName "private"'
-#   - 'AuthUserFile "/opt/rh/httpd24/root/etc/httpd/.htpasswd"'
-#   - 'RequestHeader unset Authorization'
-#   - 'Require valid-user'
+# Default: (see below, uses OIDC auth with Dex)
+#auth:
+#  - 'AuthType openid-connect'
+#  - 'Require valid-user'
+host_regex: 'head'
+auth:
+  - 'AuthType Basic'
+  - 'AuthName "Restricted Files"'
+  - 'AuthBasicProvider file'
+  - 'AuthUserFile /opt/rh/httpd24/root/etc/httpd/apache-passwords'
+  - 'Require valid-user'
 
 # Redirect user to the following URI when accessing root URI
 # Example:
@@ -157,14 +233,14 @@ ssl:
 # Example:
 #     node_uri: '/node'
 # Default: null (disable this feature)
-#node_uri: null
+node_uri: '/node'
 
 # Sub-uri used to reverse proxy to backend web server running on node that
 # ONLY uses *relative* URI paths
 # Example:
 #     rnode_uri: '/rnode'
 # Default: null (disable this feature)
-#rnode_uri: null
+rnode_uri: '/rnode'
 
 #
 # Per-user NGINX Passenger apps
@@ -196,6 +272,21 @@ ssl:
 # Default: 5 (only try 5 times)
 #pun_max_retries: 5
 
+# The PUN pre hook command to execute as root
+#
+# Example:
+#    pun_pre_hook_root_cmd: '/opt/hpc-site/ood_pun_prehook'
+# Default: null (do not run any PUN pre hook as root)
+#pun_pre_hook_root_cmd: null
+
+# Comma separated list of environment variables to pass from the apache context
+# into the PUN pre hook. Defaults to null so nothing is exported.
+#
+# Example:
+#    pun_pre_hook_exports: 'OIDC_ACCESS_TOKEN,OIDC_CLAIM_EMAIL'
+# Default: null (pass nothing)
+#pun_pre_hook_exports: null
+
 #
 # Support for OpenID Connect
 #
@@ -204,7 +295,7 @@ ssl:
 # Example:
 #     oidc_uri: '/oidc'
 # Default: null (disable OpenID Connect support)
-#oidc_uri: null
+oidc_uri: '/oidc'
 
 # Sub-uri user is redirected to if they are not authenticated. This is used to
 # *discover* what ID provider the user will login through.
@@ -240,11 +331,129 @@ ssl:
 # Default: null (display error to user if mapping fails)
 #register_root: null
 
-host_regex: 'head'
-auth:
- - 'AuthType Basic'
- - 'AuthName "Restricted Files"'
- - 'AuthBasicProvider file'
- - 'AuthDBMUserFile "/opt/rh/httpd24/root/etc/httpd/apache-passwords"'
- - 'RequestHeader unset Authorization'
- - 'Require valid-user'
+# OIDC metadata URL
+# Example:
+#     oidc_provider_metadata_url: https://example.com:5554/.well-known/openid-configuration
+# Default: null (value auto-generated if using Dex)
+#oidc_provider_metadata_url: null
+
+# OIDC client ID
+# Example:
+#     oidc_client_id: ondemand.example.com
+# Default: null (value auto-generated if using Dex)
+#oidc_client_id: null
+
+# OIDC client secret
+# Example:
+#     oidc_client_secret: 334389048b872a533002b34d73f8c29fd09efc50
+# Default: null (value auto-generated if using Dex)
+#oidc_client_secret: null
+
+# OIDC remote user claim. This is the claim that populates REMOTE_USER
+# Example:
+#     oidc_remote_user_claim: preferred_username
+# Default: preferred_username
+#oidc_remote_user_claim: preferred_username
+
+# OIDC scopes
+# Example:
+#     oidc_scope: "openid profile email groups"
+# Default: "openid profile email"
+#oidc_scope: "openid profile email"
+
+# OIDC session inactivity timeout
+# Example:
+#     oidc_session_inactivity_timeout: 28800
+# Default: 28800
+#oidc_session_inactivity_timeout: 28800
+
+# OIDC session max duration
+# Example:
+#     oidc_session_max_duration: 28800
+# Default: 28800
+#oidc_session_max_duration: 28800
+
+# OIDC max number of state cookies and if to automatically clean old cookies
+# Example:
+#     oidc_state_max_number_of_cookies: "10 true"
+# Default: "10 true"
+#oidc_state_max_number_of_cookies: "10 true"
+
+# OIDC Enable SameSite cookie
+# When ssl is defined this defaults to 'Off'
+# When ssl is not defined this defaults to 'On'
+# Example:
+#     oidc_cookie_same_site: 'Off'
+# Default: 'On'
+#oidc_cookie_same_site: 'On'
+
+# Additional OIDC settings as key-value pairs
+# Example:
+#     oidc_settings:
+#       OIDCPassIDTokenAs: serialized
+#       OIDCPassRefreshToken: On
+# Default: {} (empty hash)
+#oidc_settings: {}
+
+# The Dex URI behind Apache reverse proxy
+# Set to false or null to disable Dex behing the Apache reverse proxy
+# Example:
+#   dex_uri: /auth
+# Default: /dex
+#dex_uri: /dex
+
+# Dex configurations, values inside the "dex" structure are directly used to configure Dex
+# If the value for "dex" key is false or null, Dex support is disabled
+# Dex support will auto-enable if ondemand-dex package is installed
+#dex:
+  # Default based on if ssl key for ood-portal-generator is defined
+#  ssl: false
+  # Only used if SSL is disabled
+#  http_port: "5556"
+  # Only used if SSL is enabled
+#  https_port: "5554"
+  # tls_cert and tls_key take OnDemand configured values for ssl and copy keys to /etc/ood/dex maintaining file names
+#  tls_cert: null
+#  tls_key: null
+#  storage_file: /etc/ood/dex/dex.db
+#  grpc: null
+#  expiry: null
+  # Client ID, defaults to servername or FQDN
+#  client_id: null
+#  client_name: OnDemand
+  # Client secret, value auto generated
+  # A value that is a filesystem path can be used to store secret in a file
+#  client_secret: /etc/ood/dex/ondemand.secret
+   # The OnDemand redirectURI is auto-generated, this option allows adding additional URIs
+#  client_redirect_uris: []
+  # Additional Dex OIDC clients to configure
+#  static_clients: []
+  # The following example is to configure OpenLDAP
+  # Docs: https://github.com/dexidp/dex/blob/master/Documentation/connectors/ldap.md
+#  connectors:
+#    - type: ldap
+#      id: ldap
+#      name: LDAP
+#      config:
+#        host: openldap.my_center.edu:636
+#        insecureSkipVerify: false
+#        bindDN: cn=admin,dc=example,dc=org
+#        bindPW: admin
+#        userSearch:
+#          baseDN: ou=People,dc=example,dc=org
+#          filter: "(objectClass=posixAccount)"
+#          username: uid
+#          idAttr: uid
+#          emailAttr: mail
+#          nameAttr: gecos
+#          preferredUsernameAttr: uid
+#        groupSearch:
+#          baseDN: ou=Groups,dc=example,dc=org
+#          filter: "(objectClass=posixGroup)"
+#          userMatchers:
+#            - userAttr: DN
+#              groupAttr: member
+#          nameAttr: cn
+#  frontend:
+#    theme: ondemand
+#    dir: /usr/share/ondemand-dex/web

--- a/slurm-cluster-chart/files/ood_portal.yaml
+++ b/slurm-cluster-chart/files/ood_portal.yaml
@@ -157,7 +157,7 @@ ssl:
 #auth:
 #  - 'AuthType openid-connect'
 #  - 'Require valid-user'
-host_regex: 'head'
+#host_regex: 'head'
 auth:
   - 'AuthType Basic'
   - 'AuthName "Open OnDemand"'
@@ -295,7 +295,7 @@ rnode_uri: '/rnode'
 # Example:
 #     oidc_uri: '/oidc'
 # Default: null (disable OpenID Connect support)
-oidc_uri: '/oidc'
+# oidc_uri: '/oidc'
 
 # Sub-uri user is redirected to if they are not authenticated. This is used to
 # *discover* what ID provider the user will login through.

--- a/slurm-cluster-chart/files/ood_portal.yaml
+++ b/slurm-cluster-chart/files/ood_portal.yaml
@@ -243,8 +243,8 @@ ssl:
 host_regex: 'head'
 auth:
  - 'AuthType Basic'
- - 'AuthName "private"'
- - 'AuthBasicProvider dbm'
- - 'AuthDBMUserFile "/opt/rh/httpd24/root/etc/httpd/.htpasswd.dbm"'
+ - 'AuthName "Restricted Files"'
+ - 'AuthBasicProvider file'
+ - 'AuthDBMUserFile "/opt/rh/httpd24/root/etc/httpd/apache-passwords"'
  - 'RequestHeader unset Authorization'
  - 'Require valid-user'

--- a/slurm-cluster-chart/files/ood_portal.yaml
+++ b/slurm-cluster-chart/files/ood_portal.yaml
@@ -160,9 +160,9 @@ ssl:
 host_regex: 'head'
 auth:
   - 'AuthType Basic'
-  - 'AuthName "Restricted Files"'
-  - 'AuthBasicProvider file'
-  - 'AuthUserFile /opt/rh/httpd24/root/etc/httpd/apache-passwords'
+  - 'AuthName "Open OnDemand"'
+  - 'AuthBasicProvider PAM'
+  - 'AuthPAMService ood'
   - 'Require valid-user'
 
 # Redirect user to the following URI when accessing root URI

--- a/slurm-cluster-chart/files/ood_portal.yaml
+++ b/slurm-cluster-chart/files/ood_portal.yaml
@@ -14,7 +14,7 @@
 # Example:
 #     servername: 'www.example.com'
 # Default: null (don't use name-based Virtual Host)
-#servername: null
+servername: 128.232.226.194
 
 # The server aliases used for the name-based Virtual Host
 # Example:

--- a/slurm-cluster-chart/values.yaml
+++ b/slurm-cluster-chart/values.yaml
@@ -1,4 +1,4 @@
-slurmImage: ghcr.io/stackhpc/slurm-docker-cluster:f52e918
+slurmImage: ghcr.io/stackhpc/slurm-docker-cluster:1c11bb6
 
 replicas:
   slurmd: 2

--- a/slurm-cluster-chart/values.yaml
+++ b/slurm-cluster-chart/values.yaml
@@ -1,4 +1,4 @@
-slurmImage: ghcr.io/stackhpc/slurm-docker-cluster:1c11bb6
+slurmImage: ghcr.io/stackhpc/slurm-docker-cluster:14f5a49
 
 replicas:
   slurmd: 2


### PR DESCRIPTION
Upgrading to OnDemand 3, currently having issues with authorization for the login page, see: https://github.com/OSC/ondemand/issues/2970
This is currently fixed temporarily by a code injection in a62ee78 and a4e81d6 or by providing the login node's FIP to the ood portal config as in 06ecc8e (will need to be reverted)
Also updated to use PAM auth