### PR TITLE
Added options in Helm chart for configuring external or internal database

### DIFF
--- a/slurm-cluster-chart/templates/database-auth-secret.yaml
+++ b/slurm-cluster-chart/templates/database-auth-secret.yaml
@@ -1,18 +1,11 @@
+{{ if not .Values.databaseConnection.passwordSecretName }}
+
 apiVersion: v1
 kind: Secret
 metadata:
   name: database-auth-secret
-  {{ if not .Values.databaseConnection.password }}
   annotations:
     helm.sh/hook: pre-install
-  {{ end }}
-
-{{ if .Values.databaseConnection.password }}
-
-stringData:
-  password: {{ .Values.databaseConnection.password }}
-
-{{ else }}
 
 data:
   password: {{ randAlphaNum 32 | b64enc }}

--- a/slurm-cluster-chart/templates/database-auth-secret.yaml
+++ b/slurm-cluster-chart/templates/database-auth-secret.yaml
@@ -2,7 +2,19 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: database-auth-secret
+  {{ if not .Values.databaseConnection.password }}
   annotations:
     helm.sh/hook: pre-install
+  {{ end }}
+
+{{ if .Values.databaseConnection.password }}
+
+stringData:
+  password: {{ .Values.databaseConnection.password }}
+
+{{ else }}
+
 data:
   password: {{ randAlphaNum 32 | b64enc }}
+
+{{ end }}

--- a/slurm-cluster-chart/templates/mysql-deployment.yaml
+++ b/slurm-cluster-chart/templates/mysql-deployment.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.database.enabled }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,7 +35,7 @@ spec:
             - name: MYSQL_RANDOM_ROOT_PASSWORD
               value: "yes"
             - name: MYSQL_USER
-              value: "slurm"
+              value: {{ .Values.databaseConnection.user }}
           image: {{ .Values.database.image }}
           name: mysql
           ports:
@@ -48,3 +50,5 @@ spec:
         - name: var-lib-mysql
           persistentVolumeClaim:
             claimName: var-lib-mysql
+
+{{ end }}

--- a/slurm-cluster-chart/templates/mysql-deployment.yaml
+++ b/slurm-cluster-chart/templates/mysql-deployment.yaml
@@ -30,7 +30,11 @@ spec:
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{ if .Values.database.passwordSecretName }}
+                  name: {{ .Values.database.passwordSecretName }}
+                  {{ else }}
                   name: database-auth-secret
+                  {{ end }}
                   key: password
             - name: MYSQL_RANDOM_ROOT_PASSWORD
               value: "yes"

--- a/slurm-cluster-chart/templates/mysql-service.yaml
+++ b/slurm-cluster-chart/templates/mysql-service.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.database.enabled }}
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -5,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: slurm
     app.kubernetes.io/component: mysql
-  name: mysql
+  name: {{ .Values.databaseConnection.hostname }}
 spec:
   ports:
     - name: mysql
@@ -14,3 +16,5 @@ spec:
   selector:
     app.kubernetes.io/name: slurm
     app.kubernetes.io/component: mysql
+
+{{ end }}

--- a/slurm-cluster-chart/templates/slurmdbd-conf-configmap.yaml
+++ b/slurm-cluster-chart/templates/slurmdbd-conf-configmap.yaml
@@ -22,6 +22,6 @@ data:
     #
     # Database info
     StorageType=accounting_storage/mysql
-    StorageHost=mysql
-    StorageUser=slurm
+    StorageHost={{ .Values.databaseConnection.hostname }}
+    StorageUser={{ .Values.databaseConnection.user }}
     

--- a/slurm-cluster-chart/templates/slurmdbd-deployment.yaml
+++ b/slurm-cluster-chart/templates/slurmdbd-deployment.yaml
@@ -44,7 +44,11 @@ spec:
             - name: StoragePass
               valueFrom:
                 secretKeyRef:
+                  {{ if .Values.database.passwordSecretName }}
+                  name: {{ .Values.database.passwordSecretName }}
+                  {{ else }}
                   name: database-auth-secret
+                  {{ end }}
                   key: password
       hostname: slurmdbd
       restartPolicy: Always

--- a/slurm-cluster-chart/templates/var-lib-mysql-persistentvolumeclaim.yaml
+++ b/slurm-cluster-chart/templates/var-lib-mysql-persistentvolumeclaim.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.database.enabled }}
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,3 +14,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.database.storage }}
+
+{{ end }}

--- a/slurm-cluster-chart/values.yaml
+++ b/slurm-cluster-chart/values.yaml
@@ -72,8 +72,9 @@ databaseConnection:
   # If using the internal database, changing this field will have no effect
   # If using the external database, this user must exist on it
   user: slurm
-  # Password for database user. If left as nil, one will be randomly generated (recommended for internal database)
-  password:
+  # Name of secret containing database password. Secret should contain a 'password' key. If left as nil, a secret will be created
+  # automatically with a randomly generated password (recommended for internal database)
+  passwordSecretName:
 
 # Configmap resource names
 configmaps:

--- a/slurm-cluster-chart/values.yaml
+++ b/slurm-cluster-chart/values.yaml
@@ -52,13 +52,28 @@ rooknfs:
   # backingStorageClass: 
 
 
-
-# Values for Slurm's database container
+# Optional internally managed database deployment. If enabled, will deploy
+# MySQL server pod backed by a PVC and a service that can be resolved as databaseConnection.hostname
 database:
-  #Database image to be used
+  # If enabled, will install an internally managed database pod 
+  enabled: true
+  # Database image to be used
   image: mariadb:10.10
-  #Storage requested by the var-lib-mysql volume backing the database
+  # Storage requested by the var-lib-mysql volume backing the database
   storage: 100Mi
+
+# MySQL session connection info
+databaseConnection:
+  # Hostname of SQL server.
+  # If using the internal database, it's service will be configured to resolve with this name
+  # If using external database, should be set as its endpoint
+  hostname: mysql
+  # User with access to the Slurm accounting database on the server
+  # If using the internal database, changing this field will have no effect
+  # If using the external database, this user must exist on it
+  user: slurm
+  # Password for database user. If left as nil, one will be randomly generated (recommended for internal database)
+  password:
 
 # Configmap resource names
 configmaps:


### PR DESCRIPTION
Can now choose to enable/disable internal database in the Helm chart and provided object to give connection details for external databases

Hasn't been tested properly yet because of Arcus issues and needs external DB to test with